### PR TITLE
Fix support for nvim.

### DIFF
--- a/plugin/vipsql.vim
+++ b/plugin/vipsql.vim
@@ -1,4 +1,4 @@
-if exists('g:loaded_vipsql') || &cp || !has('channel')
+if exists('g:loaded_vipsql') || &cp || !(has('nvim') || has('channel'))
     finish
 endif
 let g:loaded_vipsql = 1


### PR DESCRIPTION
After modifying this locally, I can report that nvim functionality works as intended, but with the line as it was previously, the commands weren't available.

I am not a fan of having the feature detection be redundant here though, and I think that the function in the other file which checks "job_support_type" should be reused to avoid this kind of error in the future.